### PR TITLE
Remove Abstractions from OpenApiDefinition

### DIFF
--- a/src/OrchardCoreContrib.OpenApi.Abstractions/IOpenApiDefinition.cs
+++ b/src/OrchardCoreContrib.OpenApi.Abstractions/IOpenApiDefinition.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.OpenApi.Models;
 
-namespace OrchardCoreContrib.OpenApi.Abstractions;
+namespace OrchardCoreContrib.OpenApi;
 
 /// <summary>
 /// Represents a contract for defining OpenAPI object.

--- a/src/OrchardCoreContrib.OpenApi.Abstractions/OpenApiDefinition.cs
+++ b/src/OrchardCoreContrib.OpenApi.Abstractions/OpenApiDefinition.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.OpenApi.Models;
 
-namespace OrchardCoreContrib.OpenApi.Abstractions;
+namespace OrchardCoreContrib.OpenApi;
 
 /// <summary>
 /// Represents a base class for OpenAPI definition.


### PR DESCRIPTION
This introduces a breaking change; it could be merged once OC `3.0.0` is released