### PR TITLE
Update OrchardCoreContrib.Testing Submodule Version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,6 @@
 ﻿<Project>
 	<ItemGroup>
+		<PackageVersion Include="AngleSharp" Version="1.7.1" />
 		<PackageVersion Include="coverlet.collector" Version="10.0.1" />
 		<PackageVersion Include="linq2db" Version="6.3.0" />
 		<PackageVersion Include="MailKit" Version="4.17.0" />
@@ -44,6 +45,7 @@
 		<PackageVersion Include="OrchardCore.Workflows" Version="$(OrchardCoreVersion)" />
 		<PackageVersion Include="OrchardCoreContrib.Testing" Version="1.0.0-beta3" />
 		<PackageVersion Include="Shortcodes" Version="1.3.6" />
+		<PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.11" />
 		<PackageVersion Include="System.Text.Json" Version="10.0.8" />
 		<PackageVersion Include="xunit" Version="2.9.3" />
 		<PackageVersion Include="xunit.analyzers" Version="2.0.0-pre.51" />

--- a/src/OrchardCoreContrib.Linq/OrchardCoreContrib.Linq.csproj
+++ b/src/OrchardCoreContrib.Linq/OrchardCoreContrib.Linq.csproj
@@ -26,6 +26,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="AngleSharp" />
 		<PackageReference Include="OrchardCore.Autoroute" />
 		<PackageReference Include="OrchardCore.Alias" />
 		<PackageReference Include="OrchardCore.Users.Core" />

--- a/src/OrchardCoreContrib.Web/OrchardCoreContrib.Web.csproj
+++ b/src/OrchardCoreContrib.Web/OrchardCoreContrib.Web.csproj
@@ -15,6 +15,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="AngleSharp" />
+		<PackageReference Include="System.Security.Cryptography.Xml" NoWarn="NU1510" />
 		<PackageReference Include="OrchardCore.Logging.NLog" />
 		<PackageReference Include="OrchardCore.Application.Cms.Targets" />
 	</ItemGroup>


### PR DESCRIPTION
Updated [OrchardCoreContrib.Testing](https://github.com/OrchardCoreContrib/OrchardCoreContrib.Testing) from e7196c4 to a2c2448.

<details>
<summary>Details</summary>

_This automated submodule update was generated by workflow._

- Old commit: [e7196c4](https://github.com/OrchardCoreContrib/OrchardCoreContrib.Testing/commit/e7196c490dbfd29f8d9e5ccc6da4aa0802fbccda)
- New commit: [a2c2448](https://github.com/OrchardCoreContrib/OrchardCoreContrib.Testing/commit/a2c244858b0b13e30813a3e0a9de6b58514af00c)

[View changes](https://github.com/OrchardCoreContrib/OrchardCoreContrib.Testing/compare/e7196c490dbfd29f8d9e5ccc6da4aa0802fbccda...a2c244858b0b13e30813a3e0a9de6b58514af00c)
</details>